### PR TITLE
Rubyプラクティス >  プログラムの修正（リバーシ編）としてリバーシが正常に動作しない不具合を修正した

### DIFF
--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -47,7 +47,7 @@ module ReversiMethods
 
     # コピーした盤面にて石の配置を試みて、成功すれば反映する
     copied_board = Marshal.load(Marshal.dump(board))
-    copied_board[pos.col][pos.row] = stone_color
+    copied_board[pos.row][pos.col] = stone_color
 
     turn_succeed = false
     Position::DIRECTIONS.each do |direction|
@@ -61,7 +61,9 @@ module ReversiMethods
   end
 
   def turn(board, target_pos, attack_stone_color, direction)
+    # 盤上外、対象が空白、対象が自石の場合は反転できない
     return false if target_pos.out_of_board?
+    return false if target_pos.stone_color(board) == BLANK_CELL
     return false if target_pos.stone_color(board) == attack_stone_color
 
     next_pos = target_pos.next_position(direction)
@@ -86,6 +88,8 @@ module ReversiMethods
         return true if put_stone(board, position.to_cell_ref, attack_stone_color, dry_run: true)
       end
     end
+    # 一つも置ける場所がない場合はfalseを返す
+    false
   end
 
   def count_stone(board, stone_color)


### PR DESCRIPTION
## 背景

Rubyプラクティス > プログラムの修正（リバーシ編）としてプロダクトコードを修正した

```
雛形リポジトリにある reversi.rb を実行すると、リバーシのゲームを遊ぶことができます。

$ ruby reversi.rb
  a b c d e f g h
1 - - - - - - - -
2 - - - - - - - -
3 - - - - - - - -
4 - - - ○ ● - - -
5 - - - ● ○ - - -
6 - - - - - - - -
7 - - - - - - - -
8 - - - - - - - -
command? (黒●) >

> が表示されたら、 f5 などとマスを表す表記を記入すると、石を配置できます。
黒石・白石どちらも手動で配置する必要があります。対戦CPUの実装はありません。

このプログラムには潜在的にバグが存在します。
テストコードが準備されており、実行すると落ちます。
```

## やったこと

- [x] リバーシが正常に動作しない不具合を修正した
  - [x] put_stoneメソッドでコピーした盤面に石を設置する際の行列指定が逆だったのを修正した
  - [x] turn メソッドでひっくり返せるかのブロック節に石がない場合の処理を追加した
  - [x] placeable? メソッドの盤面に石をおけるか否かの判定で置けない場合にfalseを返すようにした

## 確認方法

`ruby test/reversi_methods_test.rb ` でテストが通っていること

![CleanShot 2024-10-03 at 22 25 34@2x](https://github.com/user-attachments/assets/a56e0360-ebae-42e2-9c20-451e51e3a8b3)
